### PR TITLE
[#94] fix d3-scale dependency import

### DIFF
--- a/src/charts/WCartesian/WCartesian.vue
+++ b/src/charts/WCartesian/WCartesian.vue
@@ -1,6 +1,6 @@
 <script>
 import VueTypes from 'vue-types'
-import scaleLinear from 'd3-scale/src/linear'
+import { scaleLinear } from 'd3-scale'
 import stack from 'd3-shape/src/stack'
 import stackOffsetDiverging from 'd3-shape/src/offset/diverging'
 import noop from 'lodash.noop'


### PR DESCRIPTION
Since d3/d3-scale changed their import strategy in the new version of the package [(Commit)](https://github.com/d3/d3-scale/commit/ac308737b99f74abd8f8fff64ced56808bde79e2#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) the dependency has to be imported directly from ```index.js``` of the package. 
